### PR TITLE
Fix CORS on freecodecamp.org domain

### DIFF
--- a/freeCodeCamp/fcctesting.js
+++ b/freeCodeCamp/fcctesting.js
@@ -39,17 +39,13 @@ const fs = require('fs');
 const cors = require('cors');
 
 module.exports = function (app) {
-  
-  app.use(function (req, res, next) {
-      var allowedOrigins = ['https://pricey-hugger.gomix.me', 'http://pricey-hugger.gomix.me', 'https://freecodecamp.com', 'https://beta.freecodecamp.com', 'http://freecodecamp.com', 'http://beta.freecodecamp.com','http://localhost:3000', 'https://localhost:3000']
-       var origin = req.headers.origin;
-        if(allowedOrigins.indexOf(origin) > -1){
-             res.setHeader('Access-Control-Allow-Origin', origin);
-        }
-      //res.setHeader('Access-Control-Allow-Origin', 'https://pricey-hugger.gomix.me');
+  app.use(
+    cors({ origin: /^https?:\/\/([\w-]+\.)*freecodecamp\.org/ }),
+    function(req, res, next) {
       res.setHeader('Access-Control-Allow-Credentials', true);
       next();
-  });
+    }
+  );
   
   app.route('/_api/server.js')
     .get(function(req, res, next) {


### PR DESCRIPTION
The repo has no tests so you may find the following output helpful:

```
$ curl -X GET -I 'http://localhost:3000/_api/server.js' -H 'Origin: https://learn.freecodecamp.org'
HTTP/1.1 200 OK
X-Powered-By: Express
Access-Control-Allow-Origin: https://learn.freecodecamp.org
Access-Control-Allow-Credentials: true
Content-Type: text/html; charset=utf-8
Content-Length: 1189
ETag: W/"4a5-JFr4thxw6wYw4ALs971fVKG0Krg"
Date: Fri, 29 Jun 2018 11:26:40 GMT
Connection: keep-alive
```

```
$ curl -X GET -I 'http://localhost:3000/_api/server.js' -H 'Origin: https://beta.freecodecamp.org'
HTTP/1.1 200 OK   
X-Powered-By: Express   
Access-Control-Allow-Origin: https://beta.freecodecamp.org
Vary: Origin                                                     
Access-Control-Allow-Credentials: true
Content-Type: text/html; charset=utf-8
Content-Length: 1189
ETag: W/"4a5-JFr4thxw6wYw4ALs971fVKG0Krg"
Date: Fri, 29 Jun 2018 11:40:24 GMT
Connection: keep-alive
```

```
$ curl -X GET -I 'http://localhost:3000/_api/server.js' -H 'Origin: https://google.com'
HTTP/1.1 200 OK
X-Powered-By: Express
Vary: Origin
Access-Control-Allow-Credentials: true
Content-Type: text/html; charset=utf-8
Content-Length: 1189
ETag: W/"4a5-JFr4thxw6wYw4ALs971fVKG0Krg"
Date: Fri, 29 Jun 2018 11:40:36 GMT
Connection: keep-alive
```

Resolves: [#17757](https://github.com/freeCodeCamp/freeCodeCamp/issues/17757)