### PR TITLE
Added learn.freecodecamp.com to bypass cors issues

### DIFF
--- a/freeCodeCamp/fcctesting.js
+++ b/freeCodeCamp/fcctesting.js
@@ -41,7 +41,7 @@ const cors = require('cors');
 module.exports = function (app) {
   
   app.use(function (req, res, next) {
-      var allowedOrigins = ['https://pricey-hugger.gomix.me', 'http://pricey-hugger.gomix.me', 'https://freecodecamp.com', 'https://beta.freecodecamp.com', 'http://freecodecamp.com', 'http://beta.freecodecamp.com','http://localhost:3000', 'https://localhost:3000']
+      var allowedOrigins = ['https://pricey-hugger.gomix.me', 'http://pricey-hugger.gomix.me', 'https://learn.freecodecamp.com', 'https://freecodecamp.com', 'https://beta.freecodecamp.com', 'http://freecodecamp.com', 'http://beta.freecodecamp.com','http://localhost:3000', 'https://localhost:3000']
        var origin = req.headers.origin;
         if(allowedOrigins.indexOf(origin) > -1){
              res.setHeader('Access-Control-Allow-Origin', origin);


### PR DESCRIPTION
Without adding https://learn.freecodecamp.com to the 'Access-Control-Allow-Origin' header, three of the four FCC tests for `Advanced Node and Express - Set up the Environment` will fail due to CORS.