### PR TITLE
Add 'https://learn.freecodecamp.com' to list of allowed origins

### DIFF
--- a/freeCodeCamp/fcctesting.js
+++ b/freeCodeCamp/fcctesting.js
@@ -41,7 +41,7 @@ const cors = require('cors');
 module.exports = function (app) {
   
   app.use(function (req, res, next) {
-      var allowedOrigins = ['https://pricey-hugger.gomix.me', 'http://pricey-hugger.gomix.me', 'https://freecodecamp.com', 'https://beta.freecodecamp.com', 'http://freecodecamp.com', 'http://beta.freecodecamp.com','http://localhost:3000', 'https://localhost:3000']
+      var allowedOrigins = ['https://pricey-hugger.gomix.me', 'http://pricey-hugger.gomix.me', 'https://freecodecamp.com', 'https://beta.freecodecamp.com', 'https://learn.freecodecamp.com', 'http://freecodecamp.com', 'http://beta.freecodecamp.com', 'http://learn.freecodecamp.com', 'http://localhost:3000', 'https://localhost:3000']
        var origin = req.headers.origin;
         if(allowedOrigins.indexOf(origin) > -1){
              res.setHeader('Access-Control-Allow-Origin', origin);


### PR DESCRIPTION
Add 'learn.freecodecamp.com' to list of allowed origins for the tests to pass
Not sure if beta.freecodecamp.com should be removed or not, so keeping it.